### PR TITLE
chore: JPA 방언 선택 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         show_sql: true
         format_sql: true
         default_batch_fetch_size: 100
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
 
 #  profiles:
 #    default: local


### PR DESCRIPTION
사용 중인 JPA 구현체 org.hibernate.dialect에서
MySQL8Dialect deprecated.
따라서 hibernate에서 권하는 MySQLDialect로 변경.
해당 방언은 MySQL 5.7 이상과 8.0 이상을 지원.